### PR TITLE
Redirect two NAR plugin links to the nar-maven-plugin website

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@ for FreeHEP. Later I extended this NAR (Native ARchive) plugin for Maven 2 to al
 standalone C and C++ code compilation. The code was donated to 
 Sonatype and later on put into github where it is currently maintained by others. Both the   
 <a href="http://duns.github.io/maven-nar-plugin/">original site</a> and the  
-<a href="https://github.com/maven-nar/nar-maven-plugin">new site</a> are on github. 
+<a href="https://maven-nar.github.io/">new site</a> are on github.
 As part of the project I used NAR to create a 
 <a href="http://duns.github.com/maven-swig-plugin/">Maven Swig Plugin</a> to run <a href="http://www.swig.org">SWIG</a>
 and created a

--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@ and created a
 <a href="http://github.com/duns/cpptasks-parallel">parallel and updated version</a> of <a href="http://ant-contrib.sourceforge.net/cpptasks/">CPPTasks</a>.
 </p>
          <p>
-            <a class="btn btn-default" role="button" href="http://duns.github.io/maven-nar-plugin/" target="_blank">View details »</a>
+            <a class="btn btn-default" role="button" href="https://maven-nar.github.io/" target="_blank">View details »</a>
          </p>
       </div>
 


### PR DESCRIPTION
The NAR plugin is an incredibly useful Maven plugin, so useful that a bunch of developers wanted to say thanks by offering to continue the development. This indeed happened, and there is an official website of the effort: https://maven-nar.github.io/.

Google searches for the NAR plugin easily lead to the website backed by this repository, so let's make it easier for users to find the NAR plugin website by linking to it in a more obvious manner.